### PR TITLE
try to implement lockless SampleBank owned by output fn alone

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use cpal::{StreamConfig};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::mpsc;
 
 fn main() -> anyhow::Result<()> {
     // Set up an audio Device.
@@ -48,43 +49,81 @@ fn main() -> anyhow::Result<()> {
     let input_state = state.clone();
     let output_state = state.clone();
 
+    let (producer, consumer) = mpsc::channel::<Clip>();
+
     let input_data_fn = move |data: &[f32], _: &cpal::InputCallbackInfo| {
         if !input_state.is_recording.load(Ordering::Acquire) {
             // We're not recording, save nothing.
             return;
         }
-        let mut samples = input_state.samples.lock().unwrap();
-        for &sample in data {
-            // Keep appending samples to the Vector
-            let len = input_state.total_samples.load(Ordering::Acquire);
-            samples[len] = sample;
-            input_state.total_samples.store(len + 1, Ordering::Release);
-            if input_state.is_first_loop.load(Ordering::Acquire) {
-                input_state.loop_len.store(len + 1, Ordering::Release);
-            }
+
+        let idx = input_state.total_samples.load(Ordering::Acquire);
+        let _ = producer.send(Clip::new(data.to_vec(), idx));
+
+        // Update state to account for newly recorded samples.
+        let len = input_state.total_samples.load(Ordering::SeqCst);
+        input_state.total_samples.store(len + data.len(), Ordering::SeqCst);
+        if input_state.is_first_loop.load(Ordering::SeqCst) {
+            input_state.loop_len.store(len + data.len(), Ordering::SeqCst);
         }
-        //println!("total_samples={}, input_loop_len={}", total_samples.load(Ordering::Acquire), input_loop_len.load(Ordering::Acquire));
+        //let mut samples = input_state.samples.lock().unwrap();
+        //for &sample in data {
+        //    // Keep appending samples to the Vector
+        //    let len = input_state.total_samples.load(Ordering::Acquire);
+        //    samples[len] = sample;
+        //    input_state.total_samples.store(len + 1, Ordering::Release);
+        //    if input_state.is_first_loop.load(Ordering::Acquire) {
+        //        input_state.loop_len.store(len + 1, Ordering::Release);
+        //    }
+        //}
     };
     let input_stream = input.build_input_stream(&config, input_data_fn, err_fn)?;
 
     // Setup output callback & stream.
     let mut output_idx = 0;
+    let mut bank = SampleBank::new(vec![0.0; 44100 * 100]);
     let output_data_fn = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-        if output_state.is_first_loop.load(Ordering::Acquire) {
+
+        let len = output_state.loop_len.load(Ordering::SeqCst);
+
+        // TODO
+        // pop Option<Vec> off the queue
+        // increase loop_len if first loop
+        // concat samples
+        match consumer.try_recv() {
+            Ok(clip) => {
+                if output_state.is_first_loop.load(Ordering::SeqCst) {
+                    println!("clip of length {} at idx {}", clip.samples.len(), clip.start);
+                    bank.write_at(clip.start, clip.samples);
+                }
+            },
+            Err(_) => {
+                // No new clips
+            },
+        }
+
+        if output_state.is_first_loop.load(Ordering::SeqCst) {
             // Bail; no playback yet.
             return;
         }
 
-        let playback_samples = output_state.samples.lock().unwrap();
-        let len = output_state.loop_len.load(Ordering::Acquire);
-        let loop_count = div_ceil(output_state.total_samples.load(Ordering::Acquire), len);
+        // Load the new loop_len
+        let len = output_state.loop_len.load(Ordering::SeqCst);
+        let loop_count = div_ceil(output_state.total_samples.load(Ordering::SeqCst), len);
+        println!("len={}, loop_count={}, output_idx={}", len, loop_count, output_idx);
+
+        // Still possible there are no clips yet, in which case we don't
+        // need to do anything.
+        if loop_count < 1 {
+            return;
+        }
 
         for sample in data {
             // Sum up all samples at each corresponding index across loops.
             let mut sum = 0.0;
             for loop_offset in 0..(loop_count - 1) {
                 let sample_idx = output_idx + len * loop_offset;
-                sum += playback_samples[sample_idx];
+                sum += bank.samples[sample_idx];
             }
             // TODO dynamic range compression!
             *sample = sum;
@@ -124,9 +163,28 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+struct SampleBank {
+    samples: Vec<f32>,
+}
+
+impl SampleBank {
+    fn new(samples: Vec<f32>) -> Self {
+        Self {
+            samples: samples,
+        }
+    }
+
+    // Write new samples contiguously to this SampleBank, starting at idx
+    fn write_at(mut self: Self, mut idx: usize, samples: Vec<f32>) {
+        for sample in samples {
+            self.samples[idx] = sample;
+            idx += 1;
+        }
+    }
+}
+
 #[derive(Clone)]
 struct State {
-    samples: Arc<Mutex<Vec<f32>>>,
     loop_len: Arc<AtomicUsize>,
     total_samples: Arc<AtomicUsize>,
     is_recording: Arc<AtomicBool>,
@@ -136,11 +194,24 @@ struct State {
 impl State {
     fn new() -> Self {
         Self {
-            samples: Arc::new(vec![0.0; 44100 * 100].into()),
             loop_len: Arc::new(0.into()),
             total_samples: Arc::new(0.into()),
             is_recording: Arc::new(true.into()),
             is_first_loop: Arc::new(true.into()),
+        }
+    }
+}
+
+struct Clip {
+    samples: Vec<f32>,
+    start: usize,
+}
+
+impl Clip {
+    fn new(samples: Vec<f32>, start: usize) -> Self {
+        Self {
+            samples: samples,
+            start: start,
         }
     }
 }
@@ -151,7 +222,9 @@ fn err_fn(err: cpal::StreamError) {
 
 #[inline]
 fn div_ceil(first: usize, other: usize) -> usize {
-    if (first % other) > 0 && other > 0 {
+    if other == 0 {
+        0
+    } else if (first % other) > 0 && other > 0 {
         first / other + 1
     } else {
         first / other

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ impl SampleBank {
     }
 
     // Write new samples contiguously to this SampleBank, starting at idx
-    fn write_at(mut self: Self, mut idx: usize, samples: Vec<f32>) {
+    fn write_at(&mut self, mut idx: usize, samples: Vec<f32>) {
         for sample in samples {
             self.samples[idx] = sample;
             idx += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc;
 


### PR DESCRIPTION
The main goal here is to avoid locks in audio callbacks. There are performance issues that could arise as well as logic issues as described [here](https://github.com/acobster/looper_proto/issues/4#issuecomment-885121599). Instead, we push each clip of samples over a channel. The output callback listens on the other end of the channel and is thus the sole owner of the samples vector.

Got stuck on:

```
   Compiling looper_proto v0.1.0 (/home/tamayo/projects/looper_proto)
error[E0525]: expected a closure that implements the `FnMut` trait, but this closure only implements `FnOnce`
   --> src/main.rs:84:26
    |
84  |     let output_data_fn = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this closure implements `FnOnce`, not `FnMut`
...
96  |                     bank.write_at(clip.start, clip.samples);
    |                     ---- closure is `FnOnce` because it moves the variable `bank` out of its environment
...
137 |     let output_stream = output.build_output_stream(&config, output_data_fn, err_fn)?;
    |                                ------------------- the requirement to implement `FnMut` derives from here

error: aborting due to previous error
```